### PR TITLE
feat: Add Slack Alerts for Error Logs 

### DIFF
--- a/modules/webhook/README.md
+++ b/modules/webhook/README.md
@@ -39,8 +39,13 @@ No modules.
 | Name | Type |
 |------|------|
 | [ibm_iam_authorization_policy.en_policy](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/resources/iam_authorization_policy) | resource |
+| [ibm_logs_alert.goldeneye_error_alert](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/resources/logs_alert) | resource |
 | [ibm_logs_outgoing_webhook.en_integration](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/resources/logs_outgoing_webhook) | resource |
+| [ibm_logs_outgoing_webhook.goldeneye_slack_integration](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/resources/logs_outgoing_webhook) | resource |
 | [time_sleep.wait_for_en_authorization_policy](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
+| [ibm_resource_instance.secrets_manager_instance](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/data-sources/resource_instance) | data source |
+| [ibm_sm_arbitrary_secret.goldeneye_webhook](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/data-sources/sm_arbitrary_secret) | data source |
+| [ibm_sm_secrets.webhook_arbitrary_secret](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/data-sources/sm_secrets) | data source |
 
 ### Inputs
 

--- a/modules/webhook/main.tf
+++ b/modules/webhook/main.tf
@@ -31,3 +31,67 @@ resource "ibm_logs_outgoing_webhook" "en_integration" {
     region_id                       = split(":", each.value.crn)[5]
   }
 }
+
+data "ibm_resource_instance" "secrets_manager_instance" {
+  name     = "Secrets Manager-Goldeneye"
+  service  = "secrets-manager"
+  location = "us-south"
+}
+
+data "ibm_sm_secrets" "webhook_arbitrary_secret" {
+  instance_id  = data.ibm_resource_instance.secrets_manager_instance.guid
+  region       = "us-south"
+  search       = "slack-incoming-webhook"
+  secret_types = ["arbitrary"]
+}
+
+
+data "ibm_sm_arbitrary_secret" "goldeneye_webhook" {
+  instance_id = data.ibm_resource_instance.secrets_manager_instance.guid
+  region      = "us-south"
+  secret_id   = one([for secret in data.ibm_sm_secrets.webhook_arbitrary_secret.secrets : secret.id])
+}
+
+locals {
+  goldeneye_slack_webhook_url = data.ibm_sm_arbitrary_secret.goldeneye_webhook.payload
+}
+
+resource "ibm_logs_outgoing_webhook" "goldeneye_slack_integration" {
+  instance_id = var.cloud_logs_instance_id
+  region      = var.cloud_logs_region
+  name        = "goldeneye-slack-integration"
+  url         = local.goldeneye_slack_webhook_url
+  type        = "ibm_event_notifications"
+}
+
+resource "ibm_logs_alert" "goldeneye_error_alert" {
+  name        = "goldeneye-error-alert"
+  instance_id = var.cloud_logs_instance_id
+  region      = var.cloud_logs_region
+  description = "Alert for error level logs in GoldenEye bot sent to Slack"
+  is_active   = true
+  severity    = "error"
+  condition {
+    new_value {
+      parameters {
+        threshold = 1.0
+        timeframe = "timeframe_1_h"
+      }
+    }
+  }
+  filters {
+    text        = "error"
+    filter_type = "text_or_unspecified"
+  }
+  incident_settings {
+    retriggering_period_seconds = 3600
+    notify_on                   = "triggered_only"
+  }
+  notification_groups {
+    notifications {
+      integration_id = ibm_logs_outgoing_webhook.goldeneye_slack_integration.id
+      notify_on      = "triggered_only"
+    }
+  }
+
+}


### PR DESCRIPTION
### Description

This PR adds error-level monitoring for the GoldenEye bot’s Code Engine job logs. Logs are now checked for entries containing “error,” and notifications are sent to the #goldeneye-alerts Slack channel via a webhook stored in Secrets Manager.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [x] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

This PR adds error-level monitoring for the GoldenEye bot’s Code Engine job logs. Logs are now checked for entries containing “error,” and notifications are sent to the #goldeneye-alerts Slack channel via a webhook stored in Secrets Manager.

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
